### PR TITLE
Update README.md

### DIFF
--- a/doc/integrazione-gateway/README.md
+++ b/doc/integrazione-gateway/README.md
@@ -895,7 +895,7 @@ curl -X 'POST' \
 
   "mode": "ATTACHMENT",
 
-  "activity": "VALIDATION",
+  "activity": "VALIDATION"
 
 }' \
 
@@ -924,7 +924,7 @@ curl -X 'POST' \
 
   "healthDataFormat": "CDA",
 
-  "activity": "VERIFICA",
+  "activity": "VERIFICA"
 
 }' \
 
@@ -955,7 +955,7 @@ curl -X 'POST' \
 
   "mode": "RESOURCE",
 
-  "activity": "VERIFICA",
+  "activity": "VERIFICA"
 
 }' \
 


### PR DESCRIPTION
La virgola dopo il campo "activity" nel json del "requestBody" causa un errore durante il parsing.

{"type":"https://govway.org/handling-errors/400/InvalidRequestContent.html","title":"InvalidRequestContent","status":400,"detail":"Request content not conform to API specification: Validation error(s) :\nAn error occurred when getting the body content from type 'multipart/form-data; boundary=------------------------9dd09376bc5b2393'.\ncom.fasterxml.jackson.core.JsonParseException: Unexpected character ('}' (code 125)): was expecting double-quote to start field name\n at [Source: (org.apache.commons.fileupload.MultipartStream$ItemInputStream); line: 1, column: 74] (code: 201)\n","govway_id":"8f88ef26-c724-11ee-9fa8-005056ae7395"}