### PR TITLE
Documento i parametri da utilizzare con curl(1) nel caso serva  connettersi tramite certificato TLS client

### DIFF
--- a/doc/integrazione-gateway/README.md
+++ b/doc/integrazione-gateway/README.md
@@ -1033,6 +1033,7 @@ Body
 _Tabella 6: Parametri Richiesta di Validazione_
 
 La compilazione errata dei parameter oppure la non compilazione dei parameter “required” comporta un errore di tipo bloccante. La non compilazione del parameter facoltativo “mode” comporta la restituzione di un errore di tipo warning, mentre la non compilazione del parameter facoltativo “healthDataFormat” non comporta errori di tipo warning. 
+Nei casi in cui é richiesta la mutua autenticazione tramite certificato TLS client occorrerá utilizzare i parametri ```--cert``` e ```--key``` nella chiamata ```curl```.
 
 Il Request Body è di tipo **multipart/form-data**, al suo interno sono previsti due parametri:
 


### PR DESCRIPTION
Specifico i parametri da utilizzare in curl(1) nel caso in cui serva la mutua autenticazione TLS